### PR TITLE
add exp/h to exp calculator

### DIFF
--- a/css/sass/_expcalculator.sass
+++ b/css/sass/_expcalculator.sass
@@ -6,11 +6,11 @@
 
 #expcalculatorform input
     margin-top: 5px
-    width: 180px
+    width: 210px
 
 #expcalculatorform label
     display: inline-block
-    width: 120px
+    width: 260px
 
 #expcalculatorsubmitbutton
     width: 70px !important

--- a/css/styles.css
+++ b/css/styles.css
@@ -757,12 +757,12 @@ ol, ul {
 
 #expcalculatorform input {
   margin-top: 5px;
-  width: 180px;
+  width: 210px;
 }
 
 #expcalculatorform label {
   display: inline-block;
-  width: 120px;
+  width: 260px;
 }
 
 #expcalculatorsubmitbutton {

--- a/expcalculator.html
+++ b/expcalculator.html
@@ -172,7 +172,7 @@
             let hours_needed = (days_needed - parseInt(days_needed)) * 24;
             let minutes_needed = (hours_needed - parseInt(hours_needed)) * 60;
             let seconds_needed = (minutes_needed - parseInt(minutes_needed)) * 60;
-            let str = "time needed to reach target level: " +  Math.round(days_needed) + " day(s), " + Math.round(hours_needed) + " hour(s), " + Math.round(minutes_needed) + " minute(s) and "  + Math.round(seconds_needed) + " second(s).";
+            let str = "time needed to reach target level: " +  Math.floor(days_needed) + " day(s), " + Math.floor(hours_needed) + " hour(s), " + Math.floor(minutes_needed) + " minute(s) and "  + Math.round(seconds_needed) + " second(s).";
             $("#expcalculatorresults .orange")[0].innerHTML += "<br/>"+str;
         });
     })();

--- a/expcalculator.html
+++ b/expcalculator.html
@@ -153,6 +153,30 @@
             target="_blank">Privacy Policy</a> page.
         <a href="" style="color:#CCCCCC;" onclick="event.preventDefault(); cookieConsentClicked()">I Understand</a>
     </div>
+    <script id="todo_put_me_in_js_file">
+    (function(){
+        let $ = document.querySelectorAll.bind(document);
+        let exp_per_hour_element=document.createElement("input");
+        exp_per_hour_element.type="text";
+        exp_per_hour_element.placeholder="add exp per hour here";
+        $("#targetlevel")[0].parentNode.insertBefore(exp_per_hour_element,$("#targetlevel")[0].nextSibling);
+        $("#targetlevel")[0].parentNode.insertBefore(document.createElement("br"),$("#targetlevel")[0].nextSibling);
+        $("#expcalculatorsubmitbutton")[0].addEventListener("click",function(){
+            let exp_per_hour = Number(exp_per_hour_element.value.trim());
+            if(exp_per_hour < 1){
+                // didn't specify any exp/h, do nothing.
+                return;
+            }
+            let exp_needed = Number($("#expcalculatorresults .orange")[0].textContent.split(" ").join("").trim())
+            let days_needed = (exp_needed/exp_per_hour)/24;
+            let hours_needed = (days_needed - parseInt(days_needed)) * 24;
+            let minutes_needed = (hours_needed - parseInt(hours_needed)) * 60;
+            let seconds_needed = (minutes_needed - parseInt(minutes_needed)) * 60;
+            let str = "time needed to reach target level: " +  Math.round(days_needed) + " day(s), " + Math.round(hours_needed) + " hour(s), " + Math.round(minutes_needed) + " minute(s) and "  + Math.round(seconds_needed) + " second(s).";
+            $("#expcalculatorresults .orange")[0].innerHTML += "<br/>"+str;
+        });
+    })();
+    </script>
 </body>
 
 </html>

--- a/expcalculator.html
+++ b/expcalculator.html
@@ -97,6 +97,9 @@
                 <label id="targetlevellabel" for="targetlevel">Target level:</label>
                 <input type="text" id="targetlevel" name="targetlevel" placeholder="enter target level e.g. 450"
                     autocomplete="off"><br>
+                <label id="explabel" for="exp">(Optional) Exp per hour (in kk/h):</label>
+                <input type="text" id="exp" name="exp" placeholder="enter exp per hour in kk e.g. 4.5"
+                    autocomplete="off"><br>
                 <input type="submit" id="expcalculatorsubmitbutton" value="Submit"
                     onclick="event.preventDefault(); submit_form()" />
             </form>
@@ -153,30 +156,6 @@
             target="_blank">Privacy Policy</a> page.
         <a href="" style="color:#CCCCCC;" onclick="event.preventDefault(); cookieConsentClicked()">I Understand</a>
     </div>
-    <script id="todo_put_me_in_js_file">
-    (function(){
-        let $ = document.querySelectorAll.bind(document);
-        let exp_per_hour_element=document.createElement("input");
-        exp_per_hour_element.type="text";
-        exp_per_hour_element.placeholder="add exp per hour here";
-        $("#targetlevel")[0].parentNode.insertBefore(exp_per_hour_element,$("#targetlevel")[0].nextSibling);
-        $("#targetlevel")[0].parentNode.insertBefore(document.createElement("br"),$("#targetlevel")[0].nextSibling);
-        $("#expcalculatorsubmitbutton")[0].addEventListener("click",function(){
-            let exp_per_hour = Number(exp_per_hour_element.value.trim());
-            if(exp_per_hour < 1){
-                // didn't specify any exp/h, do nothing.
-                return;
-            }
-            let exp_needed = Number($("#expcalculatorresults .orange")[0].textContent.split(" ").join("").trim())
-            let days_needed = (exp_needed/exp_per_hour)/24;
-            let hours_needed = (days_needed - parseInt(days_needed)) * 24;
-            let minutes_needed = (hours_needed - parseInt(hours_needed)) * 60;
-            let seconds_needed = (minutes_needed - parseInt(minutes_needed)) * 60;
-            let str = "time needed to reach target level: " +  Math.floor(days_needed) + " day(s), " + Math.floor(hours_needed) + " hour(s), " + Math.floor(minutes_needed) + " minute(s) and "  + Math.round(seconds_needed) + " second(s).";
-            $("#expcalculatorresults .orange")[0].innerHTML += "<br/>"+str;
-        });
-    })();
-    </script>
 </body>
 
 </html>

--- a/scripts/expcalculator.js
+++ b/scripts/expcalculator.js
@@ -4,14 +4,25 @@ function submit_form() {
 
   startinglevel = document.getElementById("startinglevel").value
   targetlevel = document.getElementById("targetlevel").value
+  exp_per_hour = document.getElementById("exp").value
 
   total_experience_needed = calculate_experience(startinglevel, targetlevel)
-  if (typeof total_experience_needed === 'string' ) {
+  if (typeof total_experience_needed === 'string') {
     expcalculatorresults.innerHTML = total_experience_needed
   }
   else {
     formatted_experience = numberWithSpaces(total_experience_needed)
     expcalculatorresults.innerHTML = "Total experience needed to get from level <b>" + startinglevel + "</b> to <b>" + targetlevel + "</b> is:<br><br> <b><span class=\"orange\">" + formatted_experience + "</span></b><br>"
+
+    if (exp_per_hour > 0) {
+      exp_per_hour = exp_per_hour * 1000000
+      let days_needed = (total_experience_needed / exp_per_hour) / 24;
+      let hours_needed = (days_needed - parseInt(days_needed)) * 24;
+      let minutes_needed = (hours_needed - parseInt(hours_needed)) * 60;
+      let seconds_needed = (minutes_needed - parseInt(minutes_needed)) * 60;
+      let time_to_target_level = "Time needed to reach target level: " + Math.floor(days_needed) + " day(s), " + Math.floor(hours_needed) + " hour(s), " + Math.floor(minutes_needed) + " minute(s) and " + Math.round(seconds_needed) + " second(s).";
+      expcalculatorresults.innerHTML = expcalculatorresults.innerHTML + "<br>" + time_to_target_level
+    }
   }
 }
 //Can return results off by one due to rounding, but not a significant difference


### PR DESCRIPTION
this is a super-lazy javascript implementation, i couldn't be arsed pulling the repo down to a local nginx server and setting up a "proper" development environment, i just developed the whole thing in the javascript console on https://tibiapal.com/expcalculator 
hence the 100% pure JavaScript implementation. feel free to fix it, but it works great as-is :) 

screenshot 1:  ![image](https://user-images.githubusercontent.com/1874996/163024804-5c689a23-dc5f-495b-9413-ee6124202200.png)
screenshot 2: ![image](https://user-images.githubusercontent.com/1874996/163024859-1891aa88-8770-4d1f-8433-a5729931b4e6.png)


- if you are level 123, and you want level 1234, and you make 999999 exp per hour, then you need 1297 day(s), 9 hour(s), 35 minute(s) and 2 second(s)... i hope that's right